### PR TITLE
Simplify column existence check in migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "woocommerce",
     "woocommerce-extension"
   ],
-  "version": "0.0.1-dev",
+  "version": "1.6.3",
   "type": "wordpress-plugin",
   "license": [
     "MIT"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twint-woocommerce-extension",
   "title": "WooCommerce Twint Payment",
-  "version": "0.0.1-dev",
+  "version": "1.6.3",
   "author": "WooCommerce",
   "license": "GPL-3.0+",
   "keywords": [],

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: TWINT, WooCommerce, payment gateway, express checkout
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.1
-Stable tag: 0.0.1-dev
+Stable tag: 1.6.3
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 Text Domain: twint-payment-extension

--- a/src/Constant/TwintConstant.php
+++ b/src/Constant/TwintConstant.php
@@ -8,7 +8,7 @@ use Twint\Sdk\Value\InstallSource;
 
 class TwintConstant
 {
-    public const PLUGIN_VERSION = '0.0.1-dev';
+    public const PLUGIN_VERSION = '1.6.3';
 
     public const INSTALL_SOURCE = InstallSource::DIRECT;
 

--- a/src/Setup/Migration/AddReferenceIdColumnToPairingTable.php
+++ b/src/Setup/Migration/AddReferenceIdColumnToPairingTable.php
@@ -25,7 +25,7 @@ final class AddReferenceIdColumnToPairingTable
         $column = 'ref_id';
 
         // Query to check if the column exists in the specified table
-        $exist = $this->db->get_var($wpdb->prepare("SHOW COLUMNS FROM `{$table}` LIKE %s", $column));
+        $exist = $this->db->get_var($wpdb->prepare("SHOW COLUMNS FROM `{$tableName}` LIKE %s", $column));
 
         // Check the result and act accordingly
         if (!$exist) {

--- a/src/Setup/Migration/AddReferenceIdColumnToPairingTable.php
+++ b/src/Setup/Migration/AddReferenceIdColumnToPairingTable.php
@@ -25,7 +25,7 @@ final class AddReferenceIdColumnToPairingTable
         $column = 'ref_id';
 
         // Query to check if the column exists in the specified table
-        $exist = $this->db->get_var($wpdb->prepare("SHOW COLUMNS FROM `{$tableName}` LIKE %s", $column));
+        $exist = $this->db->get_var($this->db->prepare("SHOW COLUMNS FROM `{$tableName}` LIKE %s", $column));
 
         // Check the result and act accordingly
         if (!$exist) {

--- a/src/Setup/Migration/AddReferenceIdColumnToPairingTable.php
+++ b/src/Setup/Migration/AddReferenceIdColumnToPairingTable.php
@@ -25,15 +25,7 @@ final class AddReferenceIdColumnToPairingTable
         $column = 'ref_id';
 
         // Query to check if the column exists in the specified table
-        $exist = $this->db->get_var(
-            $this->db->prepare('
-                SELECT COUNT(*)
-                FROM INFORMATION_SCHEMA.COLUMNS
-                WHERE TABLE_NAME = %s
-                AND COLUMN_NAME = %s
-                AND TABLE_SCHEMA = %s
-            ', $tableName, $column, DB_NAME)
-        );
+        $exist = $this->db->get_var($wpdb->prepare("SHOW COLUMNS FROM `{$table}` LIKE %s", $column));
 
         // Check the result and act accordingly
         if (!$exist) {

--- a/twint-woocommerce-extension.php
+++ b/twint-woocommerce-extension.php
@@ -3,7 +3,7 @@
  * Plugin Name: TWINT Payment for WooCommerce
  * Plugin URI: https://twint.ch
  * Description: TWINT Payment Plugin for WooCommerce
- * Version: 0.0.1-dev
+ * Version: 1.6.3
  * Author: TWINT
  * Author URI: https://twint.ch
  * Developer: TWINT

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "name": "TWINT Payment for WooCommerce",
-  "version": "0.0.1-dev",
-  "download_url": "https://github.com/Twint-AG/twint-woocommerce-extension/releases/download/0.0.1-dev/twint-woocommerce-extension.zip",
+  "version": "1.6.3",
+  "download_url": "https://github.com/Twint-AG/twint-woocommerce-extension/releases/download/1.6.3/twint-woocommerce-extension.zip",
   "requires": "5.9",
   "tested": "6.8.2",
   "homepage": "https://www.twint.ch/",
@@ -10,6 +10,6 @@
   "sections": {
     "description": "TWINT Payment for WooCommerce",
     "installation": "Upload the ZIP file or install it directly from the admin panel.",
-    "changelog": "Version 0.0.1-dev: Bug fixings</br>Version 1.2.7: Bug fixings and improvements</br>Version 1.2.4: Enhance the warning message for PHP-CLI support in admin areas and improve security</br>Version 1.2.2: Support NSS servers</br>Version 1.2.1: Fixing issue relative to modal display in checkout page when select other payment methods</br>Version 1.2.0: Scoped styling for admin UI to prevent conflict with WP Cookie Consent plugin.</br>Version 1.1.1: Apply scoped styling to the payment modal to prevent unintended overrides from themes.</br>Version 1.0.2: Improved security and bug fixes."
+    "changelog": "Version 1.6.3: Bug fixings</br>Version 1.2.7: Bug fixings and improvements</br>Version 1.2.4: Enhance the warning message for PHP-CLI support in admin areas and improve security</br>Version 1.2.2: Support NSS servers</br>Version 1.2.1: Fixing issue relative to modal display in checkout page when select other payment methods</br>Version 1.2.0: Scoped styling for admin UI to prevent conflict with WP Cookie Consent plugin.</br>Version 1.1.1: Apply scoped styling to the payment modal to prevent unintended overrides from themes.</br>Version 1.0.2: Improved security and bug fixes."
   }
 }


### PR DESCRIPTION
No need for DB_NAME constant anymore.

https://github.com/Twint-AG/twint-woocommerce-extension/blob/89631519d3bb2a9382d1da8821cbf847059507c9/phpstan.neon#L15